### PR TITLE
Deprecation: deprecate old way to run the container 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Dump environment on to file so that we can load it up on the crontab
-printenv > /etc/docker-env
+EXTRA_PARAMS=""
+if [[ ! -z "${TEST_CERT}" ]]; then
+    EXTRA_PARAMS="--test-cert"
+fi;
 
-# Run cron & tail logs
-cron
-touch /var/log/cert-update.log
-tail -f /var/log/cert-update.log
+exec /workdir/certbot-agent certs:update ${EXTRA_PARAMS} ${KONG_ENDPOINT} ${EMAIL} ${DOMAINS}

--- a/kubernetes/certbot-cronjob.yml
+++ b/kubernetes/certbot-cronjob.yml
@@ -47,7 +47,6 @@ spec:
           containers:
             - name: runtime
               image: phpdockerio/kong-certbot-agent:3.0.0
-              command: [ "/workdir/certbot-agent", "certs:update", "$(KONG_ENDPOINT)", "$(EMAIL)", "$(DOMAINS)" ]
               ports:
                 - name: web
                   containerPort: 80


### PR DESCRIPTION
Before, we were requiring people to actually write the CMD to run it, full path to script and all.

After this, setting the old env vars used when we had cron works again, without giving an entrypoint.

The old method still works.

Closes #45 