### PR TITLE
First domain name is not repeated in SNIs any more

### DIFF
--- a/src/Kong/Handler.php
+++ b/src/Kong/Handler.php
@@ -39,6 +39,8 @@ class Handler
      */
     public function store(Certificate $certificate, string $kongAdminUri): bool
     {
+        $domains = $certificate->getDomains();
+        $mainDomain = array_shift($domains);
         $payload = [
             'headers' => [
                 'accept' => 'application/json',
@@ -46,7 +48,7 @@ class Handler
             'json'    => [
                 'cert' => $certificate->getCert(),
                 'key'  => $certificate->getKey(),
-                'snis' => $certificate->getDomains(),
+                'snis' => $domains,
             ],
         ];
 
@@ -56,7 +58,7 @@ class Handler
         try {
             $this->guzzle->request(
                 'put',
-                \sprintf('%s/certificates/%s', $kongAdminUri, $certificate->getDomains()[0]),
+                \sprintf('%s/certificates/%s', $kongAdminUri, $mainDomain),
                 $payload
             );
         } catch (BadResponseException $ex) {


### PR DESCRIPTION
This PR fixes https://github.com/phpdocker-io/kong-certbot-agent/issues/48

The first domain name in the SNI list ist taken as the certificate identifier (as before), but now removed from the list, leaving only the other domain names in there. This prevents Kong 2.0 from returning a `400 Bad Request` response and rejecting the change.